### PR TITLE
Rebrand platform and add domain management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dBulk
+# dP
 
-dBulk - Native AI Bulk Payment Platform.
+dP - Native AI Customer Data Platform.
 
-ChatGPT-style web app for **Bulk Credit/Debit Transfers** with Excel/CSV upload, local validation rules, chat-based Q&A, and a simulated submit.
+ChatGPT-style web app for **Customers** and **Products** with Excel/CSV upload, local validation rules, chat-based Q&A, and a simulated submit.
 
 > ⚠️ This MVP calls OpenAI from the browser using your key (BYOK). For production, proxy all OpenAI requests via your server to avoid exposing secrets.
 

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>dBulk - Native AI Bulk Payment Platform</title>
+    <title>dP - Native AI Customer Data Platform</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
-  <body class="bg-neutral-950 text-neutral-100">
+  <body class="bg-white text-neutral-900">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- Rename app to "dP - Native AI Customer Data Platform"
- Switch interface to light theme with green primary buttons
- Add domain sidebar with + button and toast notifications for key actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a32908cfd08333a241ec9200135bf9