### PR TITLE
Add auth server with token management and OpenAI proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,21 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.473.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "jsonwebtoken": "^9.0.2",
+    "better-sqlite3": "^9.4.0",
+    "express-graphql": "^0.12.0",
+    "graphql": "^16.8.1",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/server/auth/db.js
+++ b/server/auth/db.js
@@ -1,0 +1,24 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+
+const dbPath = path.resolve('./server/data/auth.db');
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+const db = new Database(dbPath);
+
+db.exec(`
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  token TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked INTEGER DEFAULT 0,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+);
+`);
+
+export default db;

--- a/server/auth/graphql.js
+++ b/server/auth/graphql.js
@@ -1,0 +1,21 @@
+import { buildSchema } from 'graphql';
+import { signup, login, logout, refresh } from './service.js';
+
+export const schema = buildSchema(`
+  type AuthPayload { accessToken: String!, refreshToken: String! }
+  type Success { success: Boolean! }
+  type Query { _empty: String }
+  type Mutation {
+    signup(username: String!, password: String!): Success!
+    login(username: String!, password: String!): AuthPayload!
+    logout(refreshToken: String!): Success!
+    refresh(refreshToken: String!): AuthPayload!
+  }
+`);
+
+export const root = {
+  signup,
+  login,
+  logout,
+  refresh,
+};

--- a/server/auth/routes.js
+++ b/server/auth/routes.js
@@ -1,0 +1,46 @@
+import express from 'express';
+import { signup, login, logout, refresh } from './service.js';
+
+const router = express.Router();
+
+router.post('/signup', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const result = await signup({ username, password });
+    res.json(result);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const tokens = await login({ username, password });
+    res.json(tokens);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/logout', async (req, res) => {
+  const { refreshToken } = req.body;
+  try {
+    const result = await logout({ refreshToken });
+    res.json(result);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/refresh', async (req, res) => {
+  const { refreshToken } = req.body;
+  try {
+    const tokens = await refresh({ refreshToken });
+    res.json(tokens);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/server/auth/service.js
+++ b/server/auth/service.js
@@ -1,0 +1,63 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
+import db from './db.js';
+
+const ACCESS_SECRET = process.env.ACCESS_TOKEN_SECRET || 'access-secret';
+const ACCESS_EXPIRES_IN = '15m';
+const REFRESH_EXPIRES_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+function generateAccessToken(userId) {
+  return jwt.sign({ userId }, ACCESS_SECRET, { expiresIn: ACCESS_EXPIRES_IN });
+}
+
+function generateRefreshToken() {
+  return crypto.randomBytes(40).toString('hex');
+}
+
+export async function signup({ username, password }) {
+  const passwordHash = bcrypt.hashSync(password, 10);
+  const stmt = db.prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+  try {
+    stmt.run(username, passwordHash);
+    return { success: true };
+  } catch (err) {
+    if (err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      throw new Error('User exists');
+    }
+    throw err;
+  }
+}
+
+export async function login({ username, password }) {
+  const stmt = db.prepare('SELECT * FROM users WHERE username = ?');
+  const user = stmt.get(username);
+  if (!user) throw new Error('Invalid credentials');
+  const valid = bcrypt.compareSync(password, user.password);
+  if (!valid) throw new Error('Invalid credentials');
+  const accessToken = generateAccessToken(user.id);
+  const refreshToken = generateRefreshToken();
+  const expiresAt = Math.floor(Date.now() / 1000) + REFRESH_EXPIRES_SECONDS;
+  db.prepare('INSERT INTO refresh_tokens (token, user_id, expires_at) VALUES (?, ?, ?)').run(refreshToken, user.id, expiresAt);
+  return { accessToken, refreshToken };
+}
+
+export async function logout({ refreshToken }) {
+  db.prepare('DELETE FROM refresh_tokens WHERE token = ?').run(refreshToken);
+  return { success: true };
+}
+
+export async function refresh({ refreshToken }) {
+  const row = db.prepare('SELECT * FROM refresh_tokens WHERE token = ? AND revoked = 0').get(refreshToken);
+  if (!row) throw new Error('Invalid token');
+  if (row.expires_at < Math.floor(Date.now() / 1000)) {
+    db.prepare('DELETE FROM refresh_tokens WHERE token = ?').run(refreshToken);
+    throw new Error('Expired token');
+  }
+  db.prepare('DELETE FROM refresh_tokens WHERE token = ?').run(refreshToken);
+  const newRefresh = generateRefreshToken();
+  const expiresAt = Math.floor(Date.now() / 1000) + REFRESH_EXPIRES_SECONDS;
+  db.prepare('INSERT INTO refresh_tokens (token, user_id, expires_at) VALUES (?, ?, ?)').run(newRefresh, row.user_id, expiresAt);
+  const accessToken = generateAccessToken(row.user_id);
+  return { accessToken, refreshToken: newRefresh };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import cors from 'cors';
+import authRoutes from './auth/routes.js';
+import { schema, root } from './auth/graphql.js';
+import { graphqlHTTP } from 'express-graphql';
+import openaiProxy from './openaiProxy.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use('/auth', authRoutes);
+app.use('/auth/graphql', graphqlHTTP({ schema, rootValue: root, graphiql: true }));
+app.post('/api/chat', openaiProxy);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/server/openaiProxy.js
+++ b/server/openaiProxy.js
@@ -1,0 +1,20 @@
+export default async function openaiProxy(req, res) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing API key' });
+  }
+  try {
+    const upstream = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(req.body),
+    });
+    const data = await upstream.json();
+    res.status(upstream.status).json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -295,9 +295,9 @@ async function askOpenAI(apiKey, model, userPrompt, context) {
     ],
     temperature: 0.2,
   };
-  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+  const res = await fetch("/api/chat", {
     method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -947,7 +947,7 @@ function TransferChat({ domain, kind, rulesets, setRulesets, tasks, setTasks, ap
           : null,
       };
       let answer = "(No API key set. Go to Settings to add an OpenAI key.)";
-      if (apiKey) answer = await askOpenAI(apiKey, model, question, ctx);
+      answer = await askOpenAI(apiKey, model, question, ctx);
       setMessages((m) => [...m, { role: "assistant", type: "text", content: answer }]);
     } catch (err) {
       setMessages((m) => [...m, { role: "assistant", type: "text", content: String(err?.message || err) }]);


### PR DESCRIPTION
## Summary
- add Express server with REST/GraphQL auth routes
- store hashed credentials and revokable refresh tokens in SQLite
- proxy OpenAI chat completions through server so client never sees API key

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)


------
https://chatgpt.com/codex/tasks/task_e_68a478ef3af4833381f73df03a64f72d