### PR TITLE
feat: add OIDC login and consolidate auth

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { login as oidcLogin, logout as oidcLogout } from './oidc.js';
+import { useAuth } from './AuthContext.jsx';
 import {
   Upload,
   Zap,
@@ -498,6 +500,7 @@ export default function App() {
   const [mfaToken, setMfaToken] = useState(null);
   const [loginData, setLoginData] = useState({ username: "", password: "", code: "" });
   const csrfTokenRef = useRef("");
+  const { user } = useAuth();
 
   const addToast = (msg) => {
     const id = uid("toast");
@@ -655,37 +658,48 @@ export default function App() {
           <div className="font-semibold">dP</div>
           <Badge tone="neutral">MVP</Badge>
         </div>
-        <div className="flex items-center gap-2 text-xs text-neutral-500">
-          {accessToken ? (
-            <button onClick={handleLogout} className="underline">Logout</button>
-          ) : mfaToken ? (
-            <>
-              <input
-                value={loginData.code}
-                onChange={(e) => setLoginData((d) => ({ ...d, code: e.target.value }))}
-                placeholder="MFA code"
-                className="border rounded px-1 py-0.5"
-              />
-              <button onClick={handleVerify} className="underline">Verify</button>
-            </>
-          ) : (
-            <>
-              <input
-                value={loginData.username}
-                onChange={(e) => setLoginData((d) => ({ ...d, username: e.target.value }))}
-                placeholder="User"
-                className="border rounded px-1 py-0.5"
-              />
-              <input
-                type="password"
-                value={loginData.password}
-                onChange={(e) => setLoginData((d) => ({ ...d, password: e.target.value }))}
-                placeholder="Pass"
-                className="border rounded px-1 py-0.5"
-              />
-              <button onClick={handleLogin} className="underline">Login</button>
-            </>
-          )}
+        <div className="flex items-center gap-4 text-xs text-neutral-500">
+          <div className="flex items-center gap-2">
+            <span>OIDC:</span>
+            {user ? (
+              <button onClick={oidcLogout} className="underline">Logout</button>
+            ) : (
+              <button onClick={oidcLogin} className="underline">Login</button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <span>API:</span>
+            {accessToken ? (
+              <button onClick={handleLogout} className="underline">Logout</button>
+            ) : mfaToken ? (
+              <>
+                <input
+                  value={loginData.code}
+                  onChange={(e) => setLoginData((d) => ({ ...d, code: e.target.value }))}
+                  placeholder="MFA code"
+                  className="border rounded px-1 py-0.5"
+                />
+                <button onClick={handleVerify} className="underline">Verify</button>
+              </>
+            ) : (
+              <>
+                <input
+                  value={loginData.username}
+                  onChange={(e) => setLoginData((d) => ({ ...d, username: e.target.value }))}
+                  placeholder="User"
+                  className="border rounded px-1 py-0.5"
+                />
+                <input
+                  type="password"
+                  value={loginData.password}
+                  onChange={(e) => setLoginData((d) => ({ ...d, password: e.target.value }))}
+                  placeholder="Pass"
+                  className="border rounded px-1 py-0.5"
+                />
+                <button onClick={handleLogin} className="underline">Login</button>
+              </>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { getUser } from './oidc.js';
+
+const AuthContext = createContext({ user: undefined, setUser: () => {} });
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(undefined);
+
+  useEffect(() => {
+    getUser().then(setUser).catch(() => setUser(null));
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/src/RoleGuard.jsx
+++ b/src/RoleGuard.jsx
@@ -1,19 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { getUser } from './oidc.js';
+import React from 'react';
+import { useAuth } from './AuthContext.jsx';
 
 export default function RoleGuard({ role, children }) {
-  const [userRole, setUserRole] = useState(null);
+  const { user } = useAuth();
 
-  useEffect(() => {
-    getUser().then(user => {
-      setUserRole(user?.profile?.role || 'user');
-    });
-  }, []);
-
-  if (userRole === null) {
+  if (user === undefined) {
     return null;
   }
 
+  const userRole = user?.profile?.role || 'user';
   const allowed = Array.isArray(role) ? role : [role];
   if (allowed.length && !allowed.includes(userRole)) {
     return <div className="p-4 text-red-500">Access denied</div>;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import App from './App.jsx';
 import './index.css';
 import { handleCallback } from './oidc.js';
 import RoleGuard from './RoleGuard.jsx';
+import { AuthProvider } from './AuthContext.jsx';
 
 if (window.location.pathname === '/auth/callback') {
   handleCallback().then(() => {
@@ -12,9 +13,11 @@ if (window.location.pathname === '/auth/callback') {
 } else {
   createRoot(document.getElementById('root')).render(
     <React.StrictMode>
-      <RoleGuard role="admin">
-        <App />
-      </RoleGuard>
+      <AuthProvider>
+        <RoleGuard role="admin">
+          <App />
+        </RoleGuard>
+      </AuthProvider>
     </React.StrictMode>
   );
 }


### PR DESCRIPTION
## Summary
- add AuthContext to provide a unified OIDC user state
- expose OIDC login and logout controls alongside existing API auth
- have RoleGuard rely on shared auth context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu and subsequent npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5395f68308333987de9fdbab1122d