### PR TITLE
chore: enforce required auth secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ npm run dev
 ```
 In **Settings**, paste your OpenAI API Key to enable the **Ask** feature.
 
+## Environment Variables
+
+The server expects the following variables to be set before it starts:
+
+- `ACCESS_TOKEN_SECRET` – secret used to sign JSON Web Tokens.
+- `SESSION_SECRET` – secret for Express session encryption.
+
+See the **OIDC Configuration** section for additional variables when using an identity provider.
+
 ## Features
 - Chat-first workflow with **Import**, **Ask**, and **Task (transfer)**.
 - Excel/CSV parsing using `xlsx`.

--- a/server/auth/roles.js
+++ b/server/auth/roles.js
@@ -10,7 +10,10 @@ export const ROLE_PERMISSIONS = {
   [ROLES.ADMIN]: ['chat:write']
 };
 
-const ACCESS_SECRET = process.env.ACCESS_TOKEN_SECRET || 'access-secret';
+const ACCESS_SECRET = process.env.ACCESS_TOKEN_SECRET;
+if (!ACCESS_SECRET) {
+  throw new Error('ACCESS_TOKEN_SECRET environment variable is required');
+}
 
 export function authorize(required = []) {
   const requiredRoles = Array.isArray(required) ? required : [required];

--- a/server/auth/service.js
+++ b/server/auth/service.js
@@ -4,7 +4,10 @@ import crypto from 'crypto';
 import db from './db.js';
 import { logEvent } from './logger.js';
 
-const ACCESS_SECRET = process.env.ACCESS_TOKEN_SECRET || 'access-secret';
+const ACCESS_SECRET = process.env.ACCESS_TOKEN_SECRET;
+if (!ACCESS_SECRET) {
+  throw new Error('ACCESS_TOKEN_SECRET environment variable is required');
+}
 const ACCESS_EXPIRES_IN = '15m';
 const REFRESH_EXPIRES_SECONDS = 60 * 60 * 24 * 7; // 7 days
 

--- a/server/index.js
+++ b/server/index.js
@@ -12,10 +12,16 @@ import { authorize } from './auth/roles.js';
 
 const SESSION_TIMEOUT_MS = 15 * 60 * 1000;
 
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  console.error('SESSION_SECRET environment variable is required');
+  process.exit(1);
+}
+
 const app = express();
 app.use(cors({ origin: true, credentials: true }));
 app.use(session({
-  secret: process.env.SESSION_SECRET || 'session-secret',
+  secret: sessionSecret,
   resave: false,
   saveUninitialized: false,
   rolling: true,


### PR DESCRIPTION
## Summary
- require ACCESS_TOKEN_SECRET for auth token signing
- exit if SESSION_SECRET missing for session middleware
- document required auth environment variables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a53d6e90408333adb48b4381a6f987