### PR TITLE
feat: migrate auth storage to postgres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "lucide-react": "^0.473.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "pg": "^8.11.5"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.19.2",
     "cors": "^2.8.5",
     "jsonwebtoken": "^9.0.2",
-    "better-sqlite3": "^9.4.0",
+    "pg": "^8.11.5",
     "express-graphql": "^0.12.0",
     "graphql": "^16.8.1",
     "bcryptjs": "^2.4.3",

--- a/server/auth/migrations/001_init.sql
+++ b/server/auth/migrations/001_init.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'user'
+);
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  token TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  expires_at BIGINT NOT NULL,
+  revoked BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS oidc_users (
+  id SERIAL PRIMARY KEY,
+  provider TEXT NOT NULL,
+  sub TEXT UNIQUE NOT NULL,
+  name TEXT,
+  email TEXT
+);
+
+CREATE TABLE IF NOT EXISTS mfa (
+  user_id INTEGER PRIMARY KEY REFERENCES users(id),
+  secret TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- use `pg` and environment-based config for auth database
- add SQL migrations to recreate auth tables in PostgreSQL
- rewrite auth service and OIDC strategy to use async PostgreSQL queries

## Testing
- `node --check server/auth/db.js`
- `node --check server/auth/service.js`
- `node --check server/auth/oidcStrategy.js`
- `npm test` *(fails: Missing script "test")*
- `npm install pg` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5472b9a44833395a2ad369ccdc785