### PR TITLE
feat: add tenant-aware auth with row level security

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "server": "node server/index.js"
+    "server": "node server/index.js",
+    "test": "node --test server/auth/tenant.test.js"
   },
   "dependencies": {
     "lucide-react": "^0.473.0",

--- a/server/auth/migrations/002_tenants.sql
+++ b/server/auth/migrations/002_tenants.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS tenants (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL
+);
+
+-- Seed initial tenants
+INSERT INTO tenants (name) VALUES ('tenant_a'), ('tenant_b')
+ON CONFLICT (name) DO NOTHING;
+
+-- Add tenant_id to users and related tables
+ALTER TABLE users ADD COLUMN IF NOT EXISTS tenant_id INTEGER REFERENCES tenants(id);
+UPDATE users SET tenant_id = (SELECT id FROM tenants WHERE name = 'tenant_a') WHERE tenant_id IS NULL;
+ALTER TABLE users ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS tenant_id INTEGER REFERENCES tenants(id);
+UPDATE refresh_tokens SET tenant_id = (SELECT tenant_id FROM users WHERE id = refresh_tokens.user_id) WHERE tenant_id IS NULL;
+ALTER TABLE refresh_tokens ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE oidc_users ADD COLUMN IF NOT EXISTS tenant_id INTEGER REFERENCES tenants(id);
+UPDATE oidc_users SET tenant_id = (SELECT id FROM tenants WHERE name = 'tenant_a') WHERE tenant_id IS NULL;
+ALTER TABLE oidc_users ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE mfa ADD COLUMN IF NOT EXISTS tenant_id INTEGER REFERENCES tenants(id);
+UPDATE mfa SET tenant_id = (SELECT tenant_id FROM users WHERE id = mfa.user_id) WHERE tenant_id IS NULL;
+ALTER TABLE mfa ALTER COLUMN tenant_id SET NOT NULL;
+
+-- Enable Row Level Security
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE users FORCE ROW LEVEL SECURITY;
+ALTER TABLE refresh_tokens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE refresh_tokens FORCE ROW LEVEL SECURITY;
+ALTER TABLE oidc_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE oidc_users FORCE ROW LEVEL SECURITY;
+ALTER TABLE mfa ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mfa FORCE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY tenant_isolation_users ON users
+  USING (tenant_id = current_setting('app.tenant_id')::int)
+  WITH CHECK (tenant_id = current_setting('app.tenant_id')::int);
+
+CREATE POLICY tenant_isolation_refresh_tokens ON refresh_tokens
+  USING (tenant_id = current_setting('app.tenant_id')::int)
+  WITH CHECK (tenant_id = current_setting('app.tenant_id')::int);
+
+CREATE POLICY tenant_isolation_oidc_users ON oidc_users
+  USING (tenant_id = current_setting('app.tenant_id')::int)
+  WITH CHECK (tenant_id = current_setting('app.tenant_id')::int);
+
+CREATE POLICY tenant_isolation_mfa ON mfa
+  USING (tenant_id = current_setting('app.tenant_id')::int)
+  WITH CHECK (tenant_id = current_setting('app.tenant_id')::int);

--- a/server/auth/tenant.test.js
+++ b/server/auth/tenant.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || 'testsecret';
+process.env.PGHOST = process.env.PGHOST || '127.0.0.1';
+process.env.PGUSER = process.env.PGUSER || 'postgres';
+process.env.PGDATABASE = process.env.PGDATABASE || 'cdp_test';
+process.env.PGPASSWORD = process.env.PGPASSWORD || 'postgres';
+process.env.PGPORT = process.env.PGPORT || '5432';
+
+const { default: db } = await import('./db.js');
+const { signup, login, refresh } = await import('./service.js');
+
+test('users are isolated by tenant', async () => {
+  await db.query('TRUNCATE TABLE refresh_tokens, mfa, oidc_users, users RESTART IDENTITY CASCADE');
+  const { rows: tenantRows } = await db.query("SELECT id FROM tenants WHERE name IN ('tenant_a','tenant_b') ORDER BY name");
+  const [tenantA, tenantB] = tenantRows.map(r => r.id);
+
+  await signup({ username: 'alice', password: 'pw', tenantId: tenantA });
+  await signup({ username: 'bob', password: 'pw', tenantId: tenantB });
+
+  const { refreshToken } = await login({ username: 'alice', password: 'pw', tenantId: tenantA });
+
+  await assert.rejects(() => login({ username: 'alice', password: 'pw', tenantId: tenantB }), /Invalid credentials/);
+  await assert.rejects(() => refresh({ refreshToken, tenantId: tenantB }), /Invalid token/);
+});


### PR DESCRIPTION
## Summary
- introduce tenants table and row level security policies
- scope auth queries by tenant id
- cover cross-tenant isolation with tests

## Testing
- `npm test` *(fails: Cannot find package 'pg')*


------
https://chatgpt.com/codex/tasks/task_e_68a556e70a1c83339f4b6bc3c22937b2