### PR TITLE
feat: migrate auth to Supabase

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "express": "^4.19.2",
     "cors": "^2.8.5",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.5",
     "express-graphql": "^0.12.0",
     "graphql": "^16.8.1",
     "bcryptjs": "^2.4.3",
     "passport": "^0.7.0",
     "passport-openidconnect": "^0.4.1",
     "express-session": "^1.17.3",
-    "oidc-client-ts": "^2.2.1"
+    "oidc-client-ts": "^2.2.1",
+    "@supabase/supabase-js": "^2.42.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/server/auth/db.js
+++ b/server/auth/db.js
@@ -1,37 +1,12 @@
-import { Pool } from 'pg';
-import fs from 'fs';
-import path from 'path';
+import { createClient } from '@supabase/supabase-js';
 
-const pool = new Pool({
-  host: process.env.PGHOST,
-  port: process.env.PGPORT ? parseInt(process.env.PGPORT, 10) : undefined,
-  database: process.env.PGDATABASE,
-  user: process.env.PGUSER,
-  password: process.env.PGPASSWORD,
-  max: parseInt(process.env.PGPOOL_MAX || '10', 10)
-});
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
-  process.exit(-1);
-});
-
-async function runMigrations() {
-  const migrationsDir = path.resolve('./server/auth/migrations');
-  const files = fs.existsSync(migrationsDir)
-    ? fs.readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort()
-    : [];
-  for (const file of files) {
-    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
-    await pool.query(sql);
-  }
+if (!url || !key) {
+  throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables are required');
 }
 
-try {
-  await runMigrations();
-} catch (err) {
-  console.error('Failed to run migrations', err);
-  throw err;
-}
+const supabase = createClient(url, key);
 
-export default pool;
+export default supabase;


### PR DESCRIPTION
## Summary
- replace Postgres pool with Supabase client
- rewrite auth service and OIDC strategy to use Supabase
- adjust tenant isolation test for Supabase

## Testing
- `npm test` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68a64cf278148333bad8036b92be2996