### PR TITLE
Use undefined default for AuthContext loading state

### DIFF
--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -1,10 +1,11 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { supabase } from './supabaseClient.js';
 
-const AuthContext = createContext({ user: null });
+// undefined represents the loading state before we know the current user
+const AuthContext = createContext({ user: undefined });
 
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState(undefined);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data: { user } }) => setUser(user));


### PR DESCRIPTION
## Summary
- Initialize AuthContext with `undefined` user to represent loading state
- Keep RoleGuard handling for undefined user during auth loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a80462b76c83338c716efc4372d919