### PR TITLE
Specify signup redirect to valid URL

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -5,7 +5,11 @@ export function login({ email, password }) {
 }
 
 export function signup({ email, password }) {
-  return supabase.auth.signUp({ email, password });
+  return supabase.auth.signUp({
+    email,
+    password,
+    options: { emailRedirectTo: window.location.origin },
+  });
 }
 
 export function loginWithSSO(provider) {


### PR DESCRIPTION
## Summary
- direct signup confirmations to the app origin without a trailing slash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a862cd52cc8333a2a808ec535d5a46