### PR TITLE
feat: assign admin role during signup

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -8,7 +8,10 @@ export function signup({ email, password }) {
   return supabase.auth.signUp({
     email,
     password,
-    options: { emailRedirectTo: window.location.origin },
+    options: {
+      emailRedirectTo: window.location.origin,
+      data: { role: 'admin' },
+    },
 
   });
 }


### PR DESCRIPTION
## Summary
- add role metadata to signup requests so new users default to admin

## Testing
- `npm test`
- `node -e "import('./src/auth.js').then(m=>{global.window={location:{origin:''}};return m.signup({email:'a@test.com',password:'pass1234'});}).then(console.log).catch(err=>console.error('signup error',err));"` *(fails: Cannot read properties of undefined (reading 'VITE_SUPABASE_URL'))*


------
https://chatgpt.com/codex/tasks/task_e_68a8767bc3088333a850029090061d2c