### PR TITLE
feat: add signup verification message and unverified login handling

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -9,8 +9,13 @@ export default function Login() {
     e.preventDefault();
     setError('');
     const { error } = await login(form);
-    if (error) setError(error.message);
-    else window.location.href = '/';
+    if (error) {
+      if (error.message && error.message.toLowerCase().includes('email not confirmed')) {
+        setError('Please verify your email before logging in.');
+      } else {
+        setError(error.message);
+      }
+    } else window.location.href = '/';
   };
 
   return (

--- a/src/Signup.jsx
+++ b/src/Signup.jsx
@@ -4,13 +4,14 @@ import { signup } from './auth.js';
 export default function Signup() {
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
     const { error } = await signup(form);
     if (error) setError(error.message);
-    else window.location.href = '/login';
+    else setSuccess(true);
   };
 
   return (
@@ -20,35 +21,51 @@ export default function Signup() {
         <a href="/login" className="underline">Sign in</a>
       </nav>
       <div className="flex-grow flex items-center justify-center p-4">
-        <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-          <h1 className="text-2xl font-medium text-center">Create account</h1>
-          {error && <div className="text-sm text-red-500 text-center">{error}</div>}
-          <input
-            type="email"
-            required
-            value={form.email}
-            onChange={(e) => setForm({ ...form, email: e.target.value })}
-            placeholder="Email"
-            className="w-full border rounded px-3 py-2"
-          />
-          <input
-            type="password"
-            required
-            value={form.password}
-            onChange={(e) => setForm({ ...form, password: e.target.value })}
-            placeholder="Password"
-            className="w-full border rounded px-3 py-2"
-          />
-          <button type="submit" className="w-full bg-neutral-900 text-white rounded py-2">
-            Sign up
-          </button>
-          <p className="text-sm text-center text-neutral-600">
-            Already have an account?{' '}
-            <a href="/login" className="underline">
-              Login
-            </a>
-          </p>
-        </form>
+        {success ? (
+          <div className="w-full max-w-sm space-y-4 text-center">
+            <h1 className="text-2xl font-medium">Check your email</h1>
+            <p className="text-sm text-neutral-600">
+              We've sent a verification link to {form.email}. Please verify your
+              account to continue.
+            </p>
+            <button
+              onClick={() => (window.location.href = '/login')}
+              className="w-full bg-neutral-900 text-white rounded py-2"
+            >
+              Go to login
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+            <h1 className="text-2xl font-medium text-center">Create account</h1>
+            {error && <div className="text-sm text-red-500 text-center">{error}</div>}
+            <input
+              type="email"
+              required
+              value={form.email}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+              placeholder="Email"
+              className="w-full border rounded px-3 py-2"
+            />
+            <input
+              type="password"
+              required
+              value={form.password}
+              onChange={(e) => setForm({ ...form, password: e.target.value })}
+              placeholder="Password"
+              className="w-full border rounded px-3 py-2"
+            />
+            <button type="submit" className="w-full bg-neutral-900 text-white rounded py-2">
+              Sign up
+            </button>
+            <p className="text-sm text-center text-neutral-600">
+              Already have an account?{' '}
+              <a href="/login" className="underline">
+                Login
+              </a>
+            </p>
+          </form>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show success message after signup instructing users to verify email
- redirect to login only after acknowledging message
- show clear error for unverified accounts during login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8781f6aa8833383cec62fca589e85