### PR TITLE
Enforce HS256 for Supabase JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For Supabase authentication, set the following variables in your `.env`:
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
 - `VITE_SUPABASE_REDIRECT_URL` – URL Supabase uses after email confirmation. Make sure this URL is whitelisted in your Supabase project settings for each environment.
+- `SUPABASE_JWT_SECRET` – secret used to verify Supabase JWTs. Tokens must be signed with the `HS256` algorithm.
 
 See the **OIDC Configuration** section for additional variables when using an identity provider.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "server": "node server/index.js",
-    "test": "node --test server/auth/tenant.test.js"
+    "test": "node --test server/auth/*.test.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.42.0",

--- a/server/auth/algorithm.test.js
+++ b/server/auth/algorithm.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+
+process.env.SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET || 'testsecret';
+const { authorize } = await import('./supabaseAuth.js');
+
+function runMiddleware(mw, req) {
+  return new Promise((resolve, reject) => {
+    mw(req, { status: () => ({ json: () => reject(new Error('Unauthorized')) }) }, resolve);
+  });
+}
+
+test('rejects tokens signed with non-HS256 algorithms', async () => {
+  const token = jwt.sign(
+    { app_metadata: { role: 'user' } },
+    process.env.SUPABASE_JWT_SECRET,
+    { algorithm: 'HS512' }
+  );
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  await assert.rejects(runMiddleware(authorize(), req), /Unauthorized/);
+});
+

--- a/server/auth/supabaseAuth.js
+++ b/server/auth/supabaseAuth.js
@@ -12,7 +12,7 @@ export function authorize(required = []) {
     const token = authHeader.split(' ')[1];
     if (!token) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const payload = jwt.verify(token, JWT_SECRET);
+      const payload = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] });
       const role =
         payload?.user_metadata?.role || payload?.app_metadata?.role || payload.role || 'user';
       const tenantId =


### PR DESCRIPTION
## Summary
- Only accept HS256 when verifying Supabase JWTs
- Add test rejecting tokens signed with a different algorithm
- Document HS256 requirement and update test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8794e5268833383b8bc0283f5feb6