### PR TITLE
Add Supabase env setup and prestart checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ npm run dev
 ```
 In **Settings**, paste your OpenAI API Key to enable the **Ask** feature.
 
+## Supabase Setup
+
+1. Sign up at [Supabase](https://supabase.com/) and create a project.
+2. From the project dashboard copy the **Project URL** and **anon public key**.
+3. Create a `.env` file in the project root containing:
+
+   ```bash
+   VITE_SUPABASE_URL=https://your-project.supabase.co
+   VITE_SUPABASE_ANON_KEY=your-anon-key
+   ```
+4. Restart the dev server after adding these variables.
+
 ## Environment Variables
 
 The server expects the following variables to be set before it starts:

--- a/checkEnv.js
+++ b/checkEnv.js
@@ -1,0 +1,11 @@
+import 'dotenv/config';
+
+const required = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY'];
+const missing = required.filter((name) => !process.env[name]);
+
+if (missing.length) {
+  console.error(
+    `Missing required environment variables:\n${missing.join('\n')}`
+  );
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "server": "node server/index.js",
+    "start": "node server/index.js",
+    "prestart": "node checkEnv.js",
     "test": "node --test server/auth/*.test.js"
   },
   "dependencies": {

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,10 +3,14 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(
-    'Missing Supabase environment variables. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
-  );
+const missing = [];
+if (!supabaseUrl)
+  missing.push('VITE_SUPABASE_URL (e.g., https://your-project.supabase.co)');
+if (!supabaseAnonKey)
+  missing.push('VITE_SUPABASE_ANON_KEY (e.g., public-anon-key)');
+
+if (missing.length) {
+  throw new Error(`Missing Supabase environment variables: ${missing.join(', ')}`);
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- clarify Supabase credential setup in README
- improve Supabase client error message with variable names and examples
- add prestart script to verify required environment variables

## Testing
- `npm test`
- `node checkEnv.js` (fails when vars unset)


------
https://chatgpt.com/codex/tasks/task_e_68a8efdf7c508333b05620d8520747f5