### PR TITLE
chore: add detailed auth logging

### DIFF
--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -8,13 +8,25 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(undefined);
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data: { user } }) => setUser(user));
+    console.log('[AuthContext] initializing');
+    supabase.auth.getUser().then(({ data: { user }, error }) => {
+      if (error) {
+        console.error('[AuthContext] getUser error', error);
+      } else {
+        console.log('[AuthContext] getUser', user);
+      }
+      setUser(user);
+    });
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      console.log('[AuthContext] auth state change', { event, session });
       setUser(session?.user ?? null);
     });
-    return () => subscription.unsubscribe();
+    return () => {
+      console.log('[AuthContext] unsubscribing');
+      subscription.unsubscribe();
+    };
   }, []);
 
   return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>;

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -7,15 +7,28 @@ export default function Login() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    console.log('[Login] form submit', { email: form.email });
     setError('');
-    const { error } = await login(form);
-    if (error) {
-      if (error.message && error.message.toLowerCase().includes('email not confirmed')) {
-        setError('Please verify your email before logging in.');
+    try {
+      const { data, error } = await login(form);
+      console.log('[Login] login response', { data, error });
+      if (error) {
+        console.error('[Login] login error', error);
+        if (
+          error.message &&
+          error.message.toLowerCase().includes('email not confirmed')
+        ) {
+          setError('Please verify your email before logging in.');
+        } else {
+          setError(error.message);
+        }
       } else {
-        setError(error.message);
+        window.location.href = '/';
       }
-    } else window.location.href = '/';
+    } catch (err) {
+      console.error('[Login] unexpected error', err);
+      setError(err.message);
+    }
   };
 
   return (

--- a/src/RoleGuard.jsx
+++ b/src/RoleGuard.jsx
@@ -5,20 +5,25 @@ export default function RoleGuard({ role, children }) {
   const { user } = useAuth();
 
   if (user === undefined) {
+    console.log('[RoleGuard] user loading');
     return null;
   }
 
   if (!user) {
+    console.warn('[RoleGuard] no user, redirecting');
     window.location.href = '/login';
     return null;
   }
 
   const userRole =
     user?.user_metadata?.role || user?.app_metadata?.role || 'user';
+  console.log('[RoleGuard] checking role', { required: role, userRole });
   const allowed = Array.isArray(role) ? role : [role];
   if (allowed.length && !allowed.includes(userRole)) {
+    console.warn('[RoleGuard] access denied', { required: allowed, userRole });
     return <div className="p-4 text-red-500">Access denied</div>;
   }
 
+  console.log('[RoleGuard] access granted', { userRole });
   return <>{children}</>;
 }

--- a/src/Signup.jsx
+++ b/src/Signup.jsx
@@ -8,10 +8,21 @@ export default function Signup() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    console.log('[Signup] form submit', { email: form.email });
     setError('');
-    const { error } = await signup(form);
-    if (error) setError(error.message);
-    else setSuccess(true);
+    try {
+      const { data, error } = await signup(form);
+      console.log('[Signup] signup response', { data, error });
+      if (error) {
+        console.error('[Signup] signup error', error);
+        setError(error.message);
+      } else {
+        setSuccess(true);
+      }
+    } catch (err) {
+      console.error('[Signup] unexpected error', err);
+      setError(err.message);
+    }
   };
 
   return (

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,29 +1,78 @@
 import { supabase } from './supabaseClient.js';
 
-export function login({ email, password }) {
-  return supabase.auth.signInWithPassword({ email, password });
+export async function login({ email, password }) {
+  console.log('[Auth] login attempt', { email });
+  try {
+    const res = await supabase.auth.signInWithPassword({ email, password });
+    console.log('[Auth] login response', res);
+    return res;
+  } catch (err) {
+    console.error('[Auth] login error', err);
+    throw err;
+  }
 }
 
-export function signup({ email, password }) {
-  return supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      emailRedirectTo: import.meta.env.VITE_SUPABASE_REDIRECT_URL,
-      data: { role: 'admin' },
-    },
-
-  });
+export async function signup({ email, password }) {
+  console.log('[Auth] signup attempt', { email });
+  try {
+    const res = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: import.meta.env.VITE_SUPABASE_REDIRECT_URL,
+        data: { role: 'admin' },
+      },
+    });
+    console.log('[Auth] signup response', res);
+    return res;
+  } catch (err) {
+    console.error('[Auth] signup error', err);
+    throw err;
+  }
 }
 
 export function loginWithSSO(provider) {
-  return supabase.auth.signInWithOAuth({ provider });
+  console.log('[Auth] login with SSO', { provider });
+  return supabase.auth
+    .signInWithOAuth({ provider })
+    .then((res) => {
+      console.log('[Auth] SSO response', res);
+      return res;
+    })
+    .catch((err) => {
+      console.error('[Auth] SSO error', err);
+      throw err;
+    });
 }
 
 export function logout() {
-  return supabase.auth.signOut();
+  console.log('[Auth] logout');
+  return supabase.auth
+    .signOut()
+    .then((res) => {
+      console.log('[Auth] logout response', res);
+      return res;
+    })
+    .catch((err) => {
+      console.error('[Auth] logout error', err);
+      throw err;
+    });
 }
 
 export function getUser() {
-  return supabase.auth.getUser().then(({ data }) => data.user);
+  console.log('[Auth] getUser');
+  return supabase.auth
+    .getUser()
+    .then(({ data, error }) => {
+      if (error) {
+        console.error('[Auth] getUser error', error);
+        return null;
+      }
+      console.log('[Auth] getUser response', data);
+      return data.user;
+    })
+    .catch((err) => {
+      console.error('[Auth] getUser unexpected error', err);
+      throw err;
+    });
 }


### PR DESCRIPTION
## Summary
- log every auth action to trace signups, logins, SSO, and logouts
- surface auth state changes and role checks in the console
- add robust error handling around signup and login flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9020c84d0833398497a831d4134e6