### PR TITLE
Handle login sessions with immediate redirects

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,11 +1,30 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { login, ensureUserRole, logout } from './auth.js';
 import { Loader2 } from 'lucide-react';
+import { useAuth } from './AuthContext.jsx';
 
 export default function Login() {
+  const { user } = useAuth();
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  // If a user session already exists, redirect immediately to the main app.
+  useEffect(() => {
+    if (user) {
+      window.location.href = '/';
+    }
+  }, [user]);
+
+  if (user === undefined) {
+    return (
+      <div className="p-4 text-neutral-500">
+        Loading...
+      </div>
+    );
+  }
+
+  if (user) return null;
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter') {

--- a/src/RoleGuard.jsx
+++ b/src/RoleGuard.jsx
@@ -16,9 +16,11 @@ export default function RoleGuard({ role, children }) {
 
   if (!user) {
     console.warn('[RoleGuard] no user, redirecting');
-    logout().finally(() => {
-      window.location.href = '/login';
-    });
+    // Fire-and-forget logout so we don't block redirect on network latency.
+    // Waiting for the promise could leave the UI stuck in a loading state
+    // if the sign-out request is slow or fails. Redirect immediately.
+    logout();
+    window.location.href = '/login';
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Redirect logged-in users away from the login page
- Avoid waiting on network calls when redirecting unauthenticated users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1830689083338d5ddaa565c0e84e